### PR TITLE
Potential fix for code scanning alert no. 5: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/zipx/zipx.go
+++ b/internal/zipx/zipx.go
@@ -112,7 +112,7 @@ func Unzip(srcZip, destDir string, p Policy) (err error) {
 		if rel == "" || rel == "." {
 			continue
 		}
-		for seg := range strings.SplitSeq(rel, "/") {
+		for _, seg := range strings.Split(rel, "/") {
 			if seg == ".." {
 				return fmt.Errorf("unsafe path traversal in zip (.. segment): %q", f.Name)
 			}
@@ -134,8 +134,8 @@ func Unzip(srcZip, destDir string, p Policy) (err error) {
 		if err != nil {
 			return err
 		}
-		// must be within destReal
-		if targetAbs != destReal && !strings.HasPrefix(targetAbs, destReal+string(filepath.Separator)) {
+		// must be strictly within destReal
+		if !isPathWithinBase(destReal, targetAbs) {
 			return fmt.Errorf("unsafe path escape: %q", f.Name)
 		}
 


### PR DESCRIPTION
Potential fix for [https://github.com/bodrovis/lokex/security/code-scanning/5](https://github.com/bodrovis/lokex/security/code-scanning/5)

To fix the Zip Slip vulnerability, ensure that paths from the zip archive cannot escape the intended extraction directory, regardless of how the zip entry is crafted.  
The best way is to process the zip entry name using path-cleaning logic, split on the relevant separator, and reject any path that contains "`..`" segments after cleaning.  
Additionally, use an improved segment check with `strings.Split(rel, "/")`, and always check that the resulting absolute path is strictly inside the intended extraction directory using isPathWithinBase (which is defined above and correct).  
Edits should be made in the loop at line 98, within the path validation section. Replace the segment check (lines 115–119) with correct splitting.  
Additionally, replace the check on line 138 with a call to isPathWithinBase for clarity and correctness.

No new dependencies are required, as all necessary functionality exists in the Go standard library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
